### PR TITLE
feat(claude): route Claude Code notifications and approvals through ntf

### DIFF
--- a/dotfiles/HOME/.claude/scripts/herdr-approve.sh
+++ b/dotfiles/HOME/.claude/scripts/herdr-approve.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Claude Code の PermissionRequest hook: 承認プロンプトが出る直前に発火し、
+# macOS 通知のボタンで許可/拒否を返す。
+#
+# PreToolUse ではなく PermissionRequest を使う理由: PreToolUse は
+# permissions.allow 済みのツールでも毎回発火するので、`ls` のたびに通知が飛ぶ。
+# PermissionRequest は本当に承認が要るときだけ発火する。
+#
+# 前提: 通知のアクションボタンは通知スタイルが「通知パネル」のときだけ出る。
+# 「バナー」だとボタンが表示されず、必ずタイムアウトする。
+#
+# タイムアウト・棄却時は JSON を返さずに終了し、ターミナル側の通常の承認
+# プロンプトに委ねる。席を外していても作業が止まるだけで、勝手に許可も拒否も
+# しない。
+
+set -u
+
+NTF="$HOME/bin/ntf"
+HERDR="$HOME/.local/share/mise/installs/herdr/latest/herdr"
+TERMINAL_BUNDLE_ID="com.mitchellh.ghostty"
+
+# 通知を出して待つ秒数。hook 自体の timeout (settings.json 側) はこれより
+# 長くしておくこと。短いと hook が先に殺され、押しても反映されない。
+WAIT_SEC=240
+
+BODY_MAX_CHARS=200
+
+INPUT=$(jq -c '.' 2>/dev/null) || INPUT='{}'
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""')
+SESSION_ID="${SESSION_ID:-unknown}"
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""')
+
+# 何を承認しようとしているのか。ツール名と、Bash ならコマンド本体を出す。
+# 中身が分からないまま許可を押せてしまうのは危ないので、ここは丁寧に組む。
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')
+
+# 「許可/拒否」で答えられないツールは通知を出さずに通常フローへ委ねる。
+# AskUserQuestion は選択肢を選ぶもので、許可しても質問は消えないので無意味。
+# matcher に否定は書けないため、ここで弾く。
+case "$TOOL" in
+  AskUserQuestion) exit 0 ;;
+esac
+DETAIL=$(
+  printf '%s' "$INPUT" | jq -r '
+    (.tool_input // {})
+    | (.command // .file_path // .path // .url // .pattern // "")
+    | tostring
+  ' 2>/dev/null
+)
+
+if [ -n "$TOOL" ] && [ -n "$DETAIL" ]; then
+  BODY="${TOOL}: ${DETAIL}"
+elif [ -n "$TOOL" ]; then
+  BODY="$TOOL"
+else
+  BODY="承認が必要です"
+fi
+
+# 切り詰めは jq で行う: hook 環境に LANG がないので cut -c はバイト単位になり
+# 日本語が壊れる。
+BODY=$(
+  printf '%s' "$BODY" \
+  | jq -Rrs --argjson max "$BODY_MAX_CHARS" '
+    gsub("[\r\n\t]"; " ")
+    | if (length > $max) then .[:$max] + "…" else . end
+  '
+)
+
+# subtitle は「プロジェクト名 / 会話の話題」。並列セッションのどれが訊いて
+# いるのか、通知だけで分かるようにする。
+PROJECT=$(basename "${CWD:-$PWD}")
+PANE_ID="${HERDR_PANE_ID:-}"
+PANE_TITLE=""
+if [ -n "$PANE_ID" ]; then
+  PANE_TITLE=$(
+    "$HERDR" pane get "$PANE_ID" 2>/dev/null \
+    | jq -r '
+      (.result.pane.terminal_title_stripped // "")
+      | if (length > 50) then .[:50] + "…" else . end
+    '
+  )
+fi
+if [ -n "$PANE_TITLE" ]; then
+  SUBTITLE="${PROJECT} / ${PANE_TITLE}"
+else
+  SUBTITLE="$PROJECT"
+fi
+
+# 通知を出してボタン押下を待つ。ntf が無い・壊れている場合もここで落ちるが、
+# その場合は JSON を返さずに通常フローへ委ねたいので、失敗は握りつぶす。
+RESULT=$("$NTF" send \
+  --title "承認しますか？" \
+  --subtitle "$SUBTITLE" \
+  --body "$BODY" \
+  --id "claude-approve-${SESSION_ID}" \
+  --sound \
+  --buttons "許可,拒否" \
+  --wait \
+  --wait-timeout "$WAIT_SEC" 2>/dev/null) || RESULT=""
+
+ACTION=$(printf '%s' "$RESULT" | jq -r '.action // ""' 2>/dev/null) || ACTION=""
+INDEX=$(printf '%s' "$RESULT" | jq -r '.index // -1' 2>/dev/null) || INDEX=-1
+
+# ボタン以外 (タイムアウト・棄却・本体クリック・ntf 不在) は決定を返さない。
+# JSON を出さずに exit 0 すると Claude Code は通常の承認フローに進む。
+if [ "$ACTION" != "button" ]; then
+  # 通知に気づかず放置した場合はターミナルに戻る必要があるので、pane だけ
+  # 教えておく。stderr はユーザーに表示される。
+  [ "$ACTION" = "timeout" ] && echo "通知の承認がタイムアウトしました (${PANE_ID:-pane不明})" >&2
+  exit 0
+fi
+
+if [ "$INDEX" = "0" ]; then
+  BEHAVIOR="allow"
+else
+  BEHAVIOR="deny"
+fi
+
+jq -nc --arg behavior "$BEHAVIOR" '
+  {
+    hookSpecificOutput: {
+      hookEventName: "PermissionRequest",
+      decision: (
+        if $behavior == "allow" then
+          { behavior: "allow" }
+        else
+          { behavior: "deny", message: "通知から拒否されました" }
+        end
+      )
+    }
+  }
+'
+exit 0

--- a/dotfiles/HOME/.claude/scripts/herdr-notify.sh
+++ b/dotfiles/HOME/.claude/scripts/herdr-notify.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Claude Code の Notification / Stop hook から macOS 通知を出す。
+#
+#   Notification (承認・入力待ち) … 音あり
+#   Stop         (応答完了)       … 無音
+#
+# 通知をクリックすると発火元の herdr pane を focus してターミナルを前面化する
+# ので、並列セッションでもどれが呼んでいるか探さずに戻れる。
+#
+# herdr 自身の通知 (config.toml の [ui.toast] delivery) は off にしてある。
+# 二重通知になるため、こちらを使うなら off のままにすること。
+#
+# 使い方: herdr-notify.sh notification | herdr-notify.sh stop
+
+set -u
+
+KIND="${1:-notification}"
+
+# hook の実行環境は PATH が最小限なので、どちらもフルパスで解決する。
+NTF="$HOME/bin/ntf"
+HERDR="$HOME/.local/share/mise/installs/herdr/latest/herdr"
+TERMINAL_BUNDLE_ID="com.mitchellh.ghostty"
+
+# 本文の最大文字数 (バイトではなく文字)。macOS の通知は本文を折り返して数行
+# 表示するので、この程度なら省略されずに出る。
+BODY_MAX_CHARS=200
+
+INPUT=$(jq -c '.' 2>/dev/null) || INPUT='{}'
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""')
+# --id を "claude-" だけにしないための保険。session_id は空文字で来ることも
+# あるので、jq の // (null 限定) では拾いきれない。
+SESSION_ID="${SESSION_ID:-unknown}"
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""')
+HOOK_MESSAGE=$(printf '%s' "$INPUT" | jq -r '.message // ""')
+NOTIFICATION_TYPE=$(printf '%s' "$INPUT" | jq -r '.notification_type // ""')
+TRANSCRIPT=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""')
+
+# 本文。Notification hook の message は「承認が必要」等の定型文なのでそのまま
+# 使い、Stop では最後の応答から「何が終わったか」を取り出す。
+#
+# 末尾ではなく冒頭を取る: 応答は結論から書くので要点は先頭にあり、末尾は
+# 「次は〜します」という作業宣言や補足になりがちで、終了通知の文言として
+# 噛み合わない。
+#
+# 切り詰めは cut ではなく jq で行う: hook の実行環境には LANG がないので
+# `cut -c` がバイト単位になり、日本語の途中で切れて文字が壊れる。jq の
+# .[:n] は常に文字単位で動くのでロケールに依存しない。
+BODY=""
+if [ "$KIND" = "stop" ] && [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  BODY=$(
+    # 応答ごとに 1 個の JSON 文字列にしてから最後の 1 件を取る。
+    # -c で 1 行 1 応答になるので tail -1 が「最後の応答」になる。
+    jq -c '
+      select(.type == "assistant")
+      | (.message.content // [])
+      | map(select(.type == "text") | .text)
+      | select(length > 0)
+      | join("\n")
+      | select(. != "")
+    ' "$TRANSCRIPT" 2>/dev/null \
+    | tail -1 \
+    | jq -r --argjson max "$BODY_MAX_CHARS" '
+      split("\n")
+      # コードブロックの中身は本文にならないので落とす。
+      | reduce .[] as $l ({acc: [], code: false};
+          if ($l | ltrimstr(" ") | startswith("```")) then
+            .code = (.code | not)
+          elif .code then .
+          else .acc += [$l] end
+        )
+      | .acc
+      | map(gsub("^\\s+|\\s+$"; ""))
+      | map(select(length > 0))
+      # 見出し・箇条書き・表・引用は結論の文ではないので落とし、地の文だけを
+      # 冒頭から順に繋ぐ。1 行だけだと情報が足りないことが多いので、上限まで
+      # 使い切る。
+      | map(select(startswith("#") | not))
+      | map(select(test("^[-*+>|]") | not))
+      | map(select(test("^[0-9]+\\.") | not))
+      | join(" ")
+      # 強調とインラインコードの記号は通知では読みにくいだけなので外す。
+      | gsub("\\*\\*"; "") | gsub("`"; "")
+      | gsub("[\r\t]"; " ")
+      | if (length > $max) then .[:$max] + "…" else . end
+    '
+  )
+fi
+
+if [ "$KIND" = "stop" ]; then
+  BODY="${BODY:-完了}"
+else
+  # Notification の message も、ツール内容が入ると長くなることがあるので
+  # 同じ基準で切り詰める。
+  BODY=$(
+    printf '%s' "${HOOK_MESSAGE:-入力待ち}" \
+    | jq -Rrs --argjson max "$BODY_MAX_CHARS" '
+      gsub("[\r\n\t]"; " ")
+      | if (length > $max) then .[:$max] + "…" else . end
+    '
+  )
+fi
+
+# subtitle でどのセッションが呼んでいるかを示す。並列セッションが多いので
+# 「プロジェクト名 / 会話の話題」の形にする: プロジェクト名だけだと同じリポジトリ
+# の複数セッションを区別できず、話題だけだとどのリポジトリか分からない。
+# 話題 (herdr の pane タイトル) が取れなければプロジェクト名だけになる。
+PROJECT=$(basename "${CWD:-$PWD}")
+
+PANE_ID="${HERDR_PANE_ID:-}"
+PANE_TITLE=""
+if [ -n "$PANE_ID" ]; then
+  # ここも cut ではなく jq で切る (BODY と同じくロケール非依存にするため)。
+  PANE_TITLE=$(
+    "$HERDR" pane get "$PANE_ID" 2>/dev/null \
+    | jq -r '
+      (.result.pane.terminal_title_stripped // "")
+      | if (length > 50) then .[:50] + "…" else . end
+    '
+  )
+fi
+
+if [ -n "$PANE_TITLE" ]; then
+  SUBTITLE="${PROJECT} / ${PANE_TITLE}"
+else
+  SUBTITLE="$PROJECT"
+fi
+
+[ "$KIND" != "stop" ] && [ -n "$NOTIFICATION_TYPE" ] &&
+  SUBTITLE="${SUBTITLE} (${NOTIFICATION_TYPE})"
+
+# クリック時の遷移先。pane が分かるときは focus してから前面化する。
+# クリック時の環境は素の GUI セッションなので、フルパスかつ env は使わない。
+#
+# 引数は配列ではなく set -- で組み立てる: macOS 標準の bash 3.2 では set -u 下の
+# "${arr[@]}" が空配列で unbound エラーになる。
+if [ -n "$PANE_ID" ]; then
+  set -- --execute "$HERDR agent focus $PANE_ID && open -b $TERMINAL_BUNDLE_ID"
+else
+  set -- --activate "$TERMINAL_BUNDLE_ID"
+fi
+
+# 承認待ちだけ音を鳴らす。応答完了は都度出るので無音にしないとうるさい。
+[ "$KIND" != "stop" ] && set -- "$@" --sound
+
+# --id はセッション単位。同じセッションの後続イベントが前のバナーを置き換える
+# ので、承認待ち → 完了 と積み上がらない。
+# ntf が壊れていても hook を妨げてはいけないので出力を捨てて必ず 0 で終わる。
+"$NTF" send \
+  --title "Claude Code" \
+  --subtitle "$SUBTITLE" \
+  --body "$BODY" \
+  --id "claude-${SESSION_ID}" \
+  "$@" >/dev/null 2>&1
+
+exit 0

--- a/dotfiles/HOME/.claude/settings.json
+++ b/dotfiles/HOME/.claude/settings.json
@@ -139,6 +139,11 @@
           {
             "type": "command",
             "command": "~/.claude/scripts/rate_limits_cache.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/herdr-notify.sh stop",
+            "timeout": 10
           }
         ]
       }
@@ -161,6 +166,23 @@
           {
             "type": "command",
             "command": "~/.claude/scripts/tmux-notify.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/herdr-notify.sh notification",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/herdr-approve.sh",
+            "timeout": 300
           }
         ]
       }

--- a/dotfiles/HOME/.config/herdr/config.toml
+++ b/dotfiles/HOME/.config/herdr/config.toml
@@ -56,5 +56,11 @@ height = "60%"
 [ui]
 agent_panel_sort = "spaces"
 
+# 通知は Claude Code の hook から ntf 経由で出すので、herdr 側は黙らせる。
+# hook なら session_id や承認内容が取れ、クリックで該当 pane を focus できる。
+# Claude Code 以外の agent を使うようになったら "system" に戻す。
 [ui.toast]
-delivery = "system"
+delivery = "off"
+
+[ui.sound]
+enabled = false


### PR DESCRIPTION
## Summary
- Wire the Claude Code hooks to `ntf` (chroju/eventful) so a waiting session raises a native notification, and so the approval itself can be answered from that notification.
- `herdr-notify.sh` (Notification / Stop): subtitle is `<project> / <pane title>` — with eight sessions in parallel, neither alone identifies the caller. A click runs `herdr agent focus <pane>` and raises the terminal, landing directly on the right pane.
- `herdr-approve.sh` (PermissionRequest): posts `ntf send --wait --buttons "許可,拒否"` and maps the pressed button to `{"decision":{"behavior":"allow"|"deny"}}`. The body names the tool and its target (`Bash: git push origin main`) so Allow is never pressed blind.
- herdr's own toast and sound are switched off in `config.toml`. Its detection is terminal-output pattern matching, so it can only report "an agent is blocked", and it would double up with the hooks. Restore `delivery = "system"` if a non-Claude-Code agent comes back into use — that also stops covering Codex/Cursor, which the hooks cannot reach.

### Notes on two decisions
- **PermissionRequest, not PreToolUse**: `PreToolUse` fires on every tool call including ones already allowed by `permissions.allow`, i.e. a notification per `ls`. `AskUserQuestion` is filtered inside the script since `matcher` has no negation.
- **Body text comes from the *opening* of the last response**, not the tail. The tail is typically a "next I'll ..." aside; the conclusion is stated first. Truncation runs through `jq`, not `cut -c`: hooks run without `LANG`, where `cut -c` counts bytes and splits Japanese mid-character.

## Test plan
Both scripts were exercised with `LANG`/`LC_ALL` unset, matching the hook environment.

- Approval: real payload → notification shows `Bash: git push origin main`; Allow → `{"behavior":"allow"}`, Deny → `{"behavior":"deny",...}`. `AskUserQuestion` → no notification, no output. Timeout / dismiss / `HOME=/nonexistent` → no decision, exit 0 (falls back to the terminal prompt, never auto-allows).
- The `PermissionRequest` payload shape was confirmed by logging real invocations, not assumed.
- Notification body: heading-first, code-block-first, bullets-only, empty transcript, and 400-char Japanese all produce the intended text (`完了` fallback where there is no prose; 200 chars + `…` with no mojibake).
- Failure isolation: a missing `ntf` exits 0 from every path, so a broken install cannot block a session.

Left out of this branch deliberately: the pre-existing uncommitted changes in the working tree (CLAUDE.md wording, swift-lsp, `bin/`, raycast script) are unrelated to this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5 (1M context))